### PR TITLE
feat: add weave dashboard & rbac manager to infrastructure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add rbac-manager operator version 1.21.0 (operator version 1.9.0) to infrastructure.
+- Add weave-gitops to infrastructure.
 
 ## [0.4.0]
 

--- a/clusters/demo/flux-system/gotk-sync.yaml
+++ b/clusters/demo/flux-system/gotk-sync.yaml
@@ -11,7 +11,7 @@ spec:
     branch: main
   secretRef:
     name: flux-system
-  url: https://github.com/f4z3r/flux-demo.git
+  url: https://github.com/VincentVonBueren/flux-demo.git
 ---
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization

--- a/clusters/demo/infrastructure.yaml
+++ b/clusters/demo/infrastructure.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: flux-system
 spec:
   interval: 1m
-  url: https://github.com/f4z3r/flux-demo.git
+  url: https://github.com/VincentVonBueren/flux-demo.git
   ref:
     tag: v0.3.0
 ---

--- a/clusters/test/flux-system/gotk-sync.yaml
+++ b/clusters/test/flux-system/gotk-sync.yaml
@@ -11,7 +11,7 @@ spec:
     branch: main
   secretRef:
     name: flux-system
-  url: https://github.com/f4z3r/flux-demo.git
+  url: https://github.com/VincentvonBueren/flux-demo.git
 ---
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization

--- a/clusters/test/infrastructure.yaml
+++ b/clusters/test/infrastructure.yaml
@@ -32,3 +32,4 @@ spec:
       infrastructure_vso_release_interval: "1m"
       infrastructure_eso_release_interval: "1m"
       infrastructure_rbac_manager_release_interval: "1m"
+      weave_gitops_admin_password_hash: "$2y$10$5dupD/6yPQqkA0igKc/yoO6.g1u96V7vRICCph9bQ7FM1vkoV7GFy"

--- a/clusters/test/infrastructure.yaml
+++ b/clusters/test/infrastructure.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: flux-system
 spec:
   interval: 1m
-  url: https://github.com/f4z3r/flux-demo.git
+  url: https://github.com/VincentvonBueren/flux-demo.git
   ref:
     branch: main
 ---

--- a/devbox.lock
+++ b/devbox.lock
@@ -49,6 +49,9 @@
         }
       }
     },
+    "github:NixOS/nixpkgs/nixpkgs-unstable": {
+      "resolved": "github:NixOS/nixpkgs/59138c7667b7970d205d6a05a8bfa2d78caa3643?lastModified=1748662220&narHash=sha256-7gGa49iB9nCnFk4h%2Fg9zwjlQAyjtpgcFkODjcOQS0Es%3D"
+    },
     "kind@0.24.0": {
       "last_modified": "2024-08-31T10:12:23Z",
       "resolved": "github:NixOS/nixpkgs/5629520edecb69630a3f4d17d3d33fc96c13f6fe#kind",

--- a/infrastructure/kustomization.yaml
+++ b/infrastructure/kustomization.yaml
@@ -6,6 +6,7 @@ resources:
   - nginx/base.yaml
   - external-secrets-operator/base.yaml
   - rbac-manager/base.yaml
+  - weave-gitops/base.yaml
 
 patches:
 - patch: |-
@@ -22,6 +23,7 @@ patches:
           infrastructure_vso_release_interval: "${infrastructure_vso_release_interval:=30m}"
           infrastructure_eso_release_interval: "${infrastructure_eso_release_interval:=30m}"
           infrastructure_rbac_manager_release_interval: "${infrastructure_rbac_manager_release_interval:=30m}"
+          weave_gitops_admin_password_hash: "${weave_gitops_admin_password_hash:=$2y$05$PgacAmdgWzXfG4QpVsPiIeIDICtNUl99MxNRnM4QDa1QafiFx08w6}" # encode for demo cluster afterwards 
   target:
     group: kustomize.toolkit.fluxcd.io
     version: v1

--- a/infrastructure/rbac-manager/kustomization.yaml
+++ b/infrastructure/rbac-manager/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ns.yaml
+  - repo.yaml
+  - release.yaml

--- a/infrastructure/weave-gitops/base.yaml
+++ b/infrastructure/weave-gitops/base.yaml
@@ -1,0 +1,15 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: weave-gitops
+  namespace: flux-system
+spec:
+  interval: 5m
+  retryInterval: 1m
+  timeout: 5m
+  sourceRef:
+    kind: GitRepository
+    name: infrastructure
+  path: ./infrastructure/weave-gitops
+  prune: true
+  wait: true

--- a/infrastructure/weave-gitops/kustomization.yaml
+++ b/infrastructure/weave-gitops/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ns.yaml
+  - repo.yaml
+  - release.yaml

--- a/infrastructure/weave-gitops/ns.yaml
+++ b/infrastructure/weave-gitops/ns.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: dashboard
+  labels:
+    toolkit.fluxcd.io/tenant: sre-team

--- a/infrastructure/weave-gitops/release.yaml
+++ b/infrastructure/weave-gitops/release.yaml
@@ -1,0 +1,21 @@
+apiVersion: helm.toolkit.fluxcd.io/v2beta1
+kind: HelmRelease
+metadata:
+  annotations:
+    metadata.weave.works/description: This is the Weave GitOps Dashboard.  It provides
+      a simple way to get insights into your GitOps workloads.
+  name: weave-gitops
+  namespace: dashboard
+spec:
+  chart:
+    spec:
+      chart: weave-gitops
+      sourceRef:
+        kind: HelmRepository
+        name: weave-gitops
+  interval: 1h0m0s
+  values:
+    adminUser:
+      create: true
+      passwordHash: "${weave_gitops_admin_password_hash}"
+      username: admin

--- a/infrastructure/weave-gitops/repo.yaml
+++ b/infrastructure/weave-gitops/repo.yaml
@@ -1,0 +1,14 @@
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: HelmRepository
+metadata:
+  labels:
+    app.kubernetes.io/component: ui
+    app.kubernetes.io/created-by: weave-gitops-cli
+    app.kubernetes.io/name: weave-gitops-dashboard
+    app.kubernetes.io/part-of: weave-gitops
+  name: weave-gitops
+  namespace: dashboard
+spec:
+  interval: 1h0m0s
+  type: oci
+  url: oci://ghcr.io/weaveworks/charts


### PR DESCRIPTION
## Description

- adds weave dashboard to infrastructure (v0.38.0)
- adds rbac manager to infrastructure  (v1.9.0)

## Links
- https://github.com/weaveworks/weave-gitops/releases/tag/v0.38.0
- https://github.com/FairwindsOps/rbac-manager/releases/tag/v1.9.0